### PR TITLE
Link style tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Chrome plugin to help with aspects of linking to and from Pivotal Tracker
 
 Once installed. Refresh any page you wish to use the extension in. 
 
-The following features will be available in Chrome while the extension is loaded.
+The following features will be available/visible in Chrome while the extension is loaded.
 
 ## PT Paste Helper
 1. Get any URL on the clipbard. Eg: google doc url.
@@ -20,3 +20,6 @@ The following features will be available in Chrome while the extension is loaded
 1. Hold CTRL key down when clicking the Copy Link button on any Story or Epic
 2. The link will be placed on the clipboard in both HTML and Plain text (markdown).
 3. Paste into target (gdoc, email etc)
+
+## Modest styling tweaks
+1. Make links in tracker markup more discoverable (underline them).

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,9 @@
     "name":"PT Link Helpers",
     "content_scripts":[
       {
-       "matches":["*://*.pivotaltracker.com/*","file:///*"],
-       "js":["main.js"]
+       "css": ["styles.css"],
+       "js":["main.js"],
+       "matches":["*://*.pivotaltracker.com/*","file:///*"]
       }
     ]
   }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,3 @@
+.tracker_markup a {
+  text-decoration: underline !important;
+}


### PR DESCRIPTION
PT has a subtle link style. The look is low clutter, but it's easy to miss links. Let's fix that. 

This pr adds a small bit of overriding css to underline links. 

![image](https://user-images.githubusercontent.com/801192/235225938-7a1531d9-057f-41bb-9cf4-fdabc21020a7.png)
