### PR TITLE
hide @ char in front of comment user header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Chrome plugin to help with aspects of linking to and from Pivotal Tracker
 
 ## Installation
-1. Clone the repo to local folder
-2. `chrome://extensions/`
-3. Click `Load Unpacked`
+1. Clone the repo to local folder.
+2. `chrome://extensions/`.
+3. Click `Load Unpacked`.
 4. Select the local folder you used for the clone.
 
 Once installed. Refresh any page you wish to use the extension in. 
@@ -17,9 +17,10 @@ The following features will be available/visible in Chrome while the extension i
 3. Selected text will be replaced with Markdown for the link.
 
 ## PT Copy Link Helper
-1. Hold CTRL key down when clicking the Copy Link button on any Story or Epic
+1. Hold CTRL key down when clicking the Copy Link button on any Story or Epic.
 2. The link will be placed on the clipboard in both HTML and Plain text (markdown).
-3. Paste into target (gdoc, email etc)
+3. Paste into target (gdoc, email etc).
 
 ## Modest styling tweaks
 1. Make links in tracker markup more discoverable (underline them).
+2. Trim the @ symbol prefix from username headers.

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,8 @@
 .tracker_markup a {
   text-decoration: underline !important;
 }
+
+/* trim the leading @ from usernames */
+span[class^="username_"] {
+  text-indent: -1.5ch; /* width of @ is approx 1.5 width of 0 */
+}  


### PR DESCRIPTION
The @ symbol on the comment headers creates a [stroop effect](https://en.wikipedia.org/wiki/Stroop_effect) for some readers. This code hides the @ prefix from view via css alone and without manipulating the content. 

Aside: it might have been cleaner to use a
```
span[class^="username_"]::first-letter {
  color: transparent;    
}
```
approach but these are inline `<span>` level elements (not block) which are not in the spec for ::first-letter. Also, the `@` char is not considered a letter. 